### PR TITLE
fix: Failed to execute 'getComputedStyle'

### DIFF
--- a/src/lib/src/directives/joyride.directive.ts
+++ b/src/lib/src/directives/joyride.directive.ts
@@ -68,10 +68,10 @@ export class JoyrideDirective implements AfterViewInit {
     }
 
     private isAncestorsFixed(nativeElement: any): boolean {
+        if(!nativeElement.parentElement) return false;
         let isElementFixed = window.getComputedStyle(nativeElement.parentElement).position === 'fixed';
         if (nativeElement.nodeName === 'BODY') {
-            if (isElementFixed) return true;
-            else return false;
+            return isElementFixed;
         }
         if (isElementFixed) return true;
         else return this.isAncestorsFixed(nativeElement.parentElement);


### PR DESCRIPTION
The following error occurs when a component with "joyrideStep" directives is placed in an inactive angular-material tab
`ERROR TypeError: Failed to execute 'getComputedStyle' on 'Window': parameter 1 is not of type 'Element'.
`

If app-example-component-two has at least one "joyrideStep" directive then the error will be thrown.
`<mat-tab label="tab1"> <!-- active tab--> <app-example-component-one></app-example-component-one> </mat-tab> <mat-tab label="tab2"> <!-- inactive tab--> <app-example-component-two></app-example-component-two> </mat-tab>
`