### PR TITLE
added support for server side rendering (angular universal)

### DIFF
--- a/src/lib/src/services/document.service.ts
+++ b/src/lib/src/services/document.service.ts
@@ -1,5 +1,6 @@
-import { Injectable, ElementRef } from '@angular/core';
+import { Injectable, ElementRef, Inject, PLATFORM_ID } from '@angular/core';
 import { DomRefService } from './dom.service';
+import { isPlatformBrowser } from "@angular/common";
 
 export interface IDocumentService {
     getElementFixedTop(elementRef: ElementRef): number;
@@ -23,7 +24,10 @@ export interface IDocumentService {
 export class DocumentService implements IDocumentService {
     private documentHeight: number;
 
-    constructor(private readonly DOMService: DomRefService) {
+    constructor(private readonly DOMService: DomRefService, @Inject(PLATFORM_ID) platformId: Object) {
+        if (!isPlatformBrowser(platformId)) {
+            return;
+        }
         this.setDocumentHeight();
         if (!document.elementsFromPoint) {
             // IE 11 - Edge browsers


### PR DESCRIPTION
I need support for server side rendering using angular universal. The problem with this is that there is no `document` on server side, so you have to check if the dom exists before using it:

    if (isPlatformBrowser(platformId)) {
        // ...
    }

I added that check in your `DocumentService` to be able to use this lib with angular universal.