### PR TITLE
Waiting on router.navigate() to show next step

### DIFF
--- a/projects/ngx-joyride/src/lib/services/joyride-step.service.ts
+++ b/projects/ngx-joyride/src/lib/services/joyride-step.service.ts
@@ -105,10 +105,10 @@ export class JoyrideStepService implements IJoyrideStepService {
         this.tryShowStep(StepActionType.NEXT);
     }
 
-    private navigateToStepPage(action: StepActionType) {
+    private async navigateToStepPage(action: StepActionType) {
         let stepRoute = this.stepsContainerService.getStepRoute(action);
         if (stepRoute) {
-            this.router.navigate([stepRoute]);
+            return await this.router.navigate([stepRoute]);
         }
     }
 
@@ -120,8 +120,8 @@ export class JoyrideStepService implements IJoyrideStepService {
         });
     }
 
-    private tryShowStep(actionType: StepActionType) {
-        this.navigateToStepPage(actionType);
+    private async tryShowStep(actionType: StepActionType) {
+        await this.navigateToStepPage(actionType);
         const timeout = this.optionsService.getWaitingTime();
         if (timeout > 100) this.backDropService.remove();
         setTimeout(() => {


### PR DESCRIPTION
Encountered some race conditions where the Step Service would try to locate and show the Joyride steps before router.navigate() had finished, and thus before the steps were present.

Navigation is now async, so we can await before trying to show the step.